### PR TITLE
add forge 1.20.1 emi support

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,6 +4,7 @@ manual = ['jei1', 'jei2', 'jei3', 'psi']
 suffix = [
     'net.minecraft.client.searchtree.ResourceLocationSearchTree:m_235212_(Ljava/util/List;Ljava/util/function/Function;)Lnet/minecraft/client/searchtree/ResourceLocationSearchTree;',  # Vanilla
     'net.minecraft.client.searchtree.PlainTextSearchTree:m_235197_(Ljava/util/List;Ljava/util/function/Function;)Lnet/minecraft/client/searchtree/PlainTextSearchTree;', # Vanilla
+    "dev.emi.emi.search.EmiSearch:bake()V"
 ]
 contains = [
     'com.blamejared.controlling.client.gui.GuiNewControls:lambda$filterKeys$11(Lcom/blamejared/controlling/client/gui/GuiNewKeyBindingList$KeyEntry;)Z',  # Controlling
@@ -92,7 +93,8 @@ contains = [
     'appeng.client.gui.me.patternaccess.PatternAccessTermScreen:itemStackMatchesSearchTerm(Lnet/minecraft/world/item/ItemStack;Ljava/lang/String;)Z',#since Applied Energistics 2-12.9.5
     'appeng.client.gui.me.patternaccess.PatternAccessTermScreen:refreshList()V',#since Applied Energistics 2-12.9.5
     'com.github.einjerjar.mc.keymap.client.gui.widgets.KeymapListWidget:lambda$updateFilteredList$1(Lcom/github/einjerjar/mc/keymap/client/gui/widgets/KeymapListWidget$KeymapListEntry;Ljava/lang/String;)Z', #keymap since keymap-0.8.0
-
+    "dev.emi.emi.search.NameQuery:matchesUnbaked(Ldev/emi/emi/api/stack/EmiStack;)Z"
+    "dev.emi.emi.search.TooltipQuery:matchesUnbaked(Ldev/emi/emi/api/stack/EmiStack;)Z"
 ]
 equals = [
     'vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers$CorporeaStringMatcher:equalOrContain(Ljava/lang/String;)Z',  # Botania (Corporea)
@@ -127,7 +129,8 @@ regExp = [
     'appeng.client.gui.me.search.SearchPredicates:lambda$createTooltipPredicate$4(Lappeng/client/gui/me/search/RepoSearch;Ljava/util/regex/Pattern;Lappeng/menu/me/common/GridInventoryEntry;)Z',
     'appeng.client.gui.me.search.SearchPredicates:lambda$createNamePredicate$3(Ljava/util/regex/Pattern;Lappeng/menu/me/common/GridInventoryEntry;)Z', #since Applied Energistics 2-12.9.5
     'appeng.client.gui.me.search.SearchPredicates:lambda$createTooltipPredicate$4(Lappeng/client/gui/me/search/RepoSearch;Ljava/util/regex/Pattern;Lappeng/menu/me/common/GridInventoryEntry;)Z' #since Applied Energistics 2-12.9.5
-
+    "dev.emi.emi.search.RegexTooltipQuery:matches(Ldev/emi/emi/api/stack/EmiStack;)Z"
+    "dev.emi.emi.search.RegexNameQuery:matches(Ldev/emi/emi/api/stack/EmiStack;)Z"
 ]
 
 pattern = """// Generated


### PR DESCRIPTION
有人在模组支持里提了， https://github.com/Towdium/JustEnoughCharacters/issues/34#issuecomment-1622635106 ，不过一直没有更新
我不懂怎么排查该模组相关的调用栈，我只是对照着fabric版jar里的mixin.ini里面有关emi的条目，把/jech profile得到的对应的条目添加到了generate.py文件里
看起来是没问题的
![2023-07-19_23 11 30](https://github.com/Towdium/JustEnoughCharacters/assets/48177092/ef45db9c-4e92-4822-81fb-5bd42a94192d)
