### PR TITLE
Upgrade to Minecraft 26.1+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'fabric-loom' version '1.14-SNAPSHOT' apply false
-    id 'net.neoforged.moddev' version '2.0.123' apply false
+    id 'net.fabricmc.fabric-loom' version '1.16-SNAPSHOT' apply false
+    id 'net.neoforged.moddev' version '2.0.141' apply false
 }
 
 subprojects { Project subproject ->
@@ -10,7 +10,6 @@ subprojects { Project subproject ->
         maven { url = "https://dvs1.progwml6.com/files/maven/" }
         maven { url = "https://maven.blamejared.com/" }
         maven { url = "https://modmaven.dev" }
-        maven { url = 'https://maven.parchmentmc.org' }
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,10 +13,6 @@ neoForge {
         }
     }
 
-    parchment {
-        minecraftVersion = parchment_minecraft_version
-        mappingsVersion = parchment_mappings_version
-    }
 }
 
 

--- a/common/src/main/java/me/towdium/jecharacters/JustEnoughCharacters.java
+++ b/common/src/main/java/me/towdium/jecharacters/JustEnoughCharacters.java
@@ -14,7 +14,7 @@ public class JustEnoughCharacters {
     public static boolean messageSent = false;
 
     public static void printMessage(Component message) {
-        Minecraft.getInstance().schedule(() -> Minecraft.getInstance().gui.getChat().addMessage(message));
+        Minecraft.getInstance().schedule(() -> Minecraft.getInstance().gui.getChat().addClientSystemMessage(message));
     }
 
 }

--- a/coremod-neoforge/build.gradle
+++ b/coremod-neoforge/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom"
+    id "net.fabricmc.fabric-loom"
     id 'java-library'
     id 'idea'
     id 'dev.vfyjxf.gradle.jech'
@@ -15,14 +15,13 @@ base {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings loom.officialMojangMappings()
     compileOnly project(':common')
     implementation "com.github.towdium:PinIn:${verpinin}"
     include "com.github.Towdium:PinIn:${verpinin}"
     implementation project(":coremod-common")
     compileOnly "mezz.jei:jei-${minecraft_version}-core:${jei_version}"
-    modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
+    implementation  "net.fabricmc:fabric-loader:${fabric_loader_version}"
+    implementation  "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
     compileOnly 'com.google.auto.service:auto-service-annotations:1.1.1'
     annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
 }
@@ -46,12 +45,12 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 21
+    it.options.release = 25
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 idea {

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,1 +1,1 @@
-suffixClassName=net/minecraft/class_1128
+suffixClassName=net/minecraft/client/searchtree/SuffixArray

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
     "jecharacters.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.6",
-    "fabric": "*",
-    "minecraft": ">=1.16.5",
+    "fabricloader": ">=0.19.2",
+    "fabric-api": ">=0.145.1+26.1",
+    "minecraft": ">=26.1",
     "java": ">=8"
   }
 }

--- a/fabric/src/main/resources/jecharacters.mixins.json
+++ b/fabric/src/main/resources/jecharacters.mixins.json
@@ -1,7 +1,7 @@
 {
   "package": "me.towdium.jecharacters.mixin",
   "required": true,
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "plugin": "me.towdium.jecharacters.mixin.JechMixinPlugin",
   "client": [
     "MixinClientLevel"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,14 +10,12 @@ verspec=4.6
 verbuild=0
 verpinin=1.6.0
 #platform
-minecraft_version=1.21.10
-parchment_minecraft_version=1.21.10
-parchment_mappings_version=2025.10.12
-neo_form_version=1.21.10-20251010.172816
-neo_version=21.10.64
-neo_version_range=[21.10.64,)
+minecraft_version=26.1
+neo_form_version=26.1-1
+neo_version=26.1.0.19-beta
+neo_version_range=[26.1,)
 loader_version_range=[4,)
-fabric_version=0.138.3+1.21.10
-fabric_loader_version=0.18.2
+fabric_version=0.145.1+26.1
+fabric_loader_version=0.19.2
 #mod deps
-jei_version=26.2.0.27
+jei_version=29.2.0.21

--- a/gradle/scripts/generate.gradle
+++ b/gradle/scripts/generate.gradle
@@ -28,13 +28,6 @@ var generateTargetsJson = tasks.register("generateTargetsJson") {
         JsonArray array = new JsonArray()
         for (target in value) {
             def remap = target
-            mappings.entrySet().forEach {
-                if (target.contains(it.key)) {
-                    if (isFabric) {
-                        remap = target.replace(it.key, mappings.getOrDefault(it.key, it.key))
-                    }
-                }
-            }
             if (isFabric && containsNeoFluidStack(remap)) continue
             array.add(remap)
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -29,11 +29,6 @@ neoForge {
         }
     }
 
-    parchment {
-        minecraftVersion = parchment_minecraft_version
-        mappingsVersion = parchment_mappings_version
-    }
-
     mods {
         "${mod_id}" {
             sourceSet(sourceSets.main)


### PR DESCRIPTION
- JAVA_21 -> JAVA_25
- Gradle Wrapper 9.2.1 -> 9.4.1
  - `fabric-loom`新版需求>=9.4.0
- JustEnoughCharacters.java: 官方修改了`addMessage`的定义，原来的方法变成了`addClientSystemMessage`
- 26.1之后官方已取消混淆:
  - 移除Parchment: Parchment并未更新支持
  - 移除mappings: 更新fabric，参考 [https://docs.fabricmc.net/develop/porting/#build-script](https://docs.fabricmc.net/develop/porting/#build-script)
  - `suffixClassName`: Fabric现在获取到的是未混淆的类名，导致transformConstruct方法中的类名匹配不上，hook失败（表现为创造模式搜索框无法使用拼音搜索），所以改回了未混淆的类名 `net/minecraft/client/searchtree/SuffixArray` 