### PR TITLE
Add support for Ars Zero search bar

### DIFF
--- a/generate.yaml
+++ b/generate.yaml
@@ -37,6 +37,7 @@
   "betterquesting.api2.client.gui.panels.lists.CanvasFileDirectory:queryMatches(Ljava/io/File;Ljava/lang/String;Ljava/util/ArrayDeque;)V", #Better Questing
   "com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook:onSearchChanged(Ljava/lang/String;)V", #Ars Nouveau
   "com.hollingsworth.arsnouveau.client.gui.book.GlyphUnlockMenu:onSearchChanged(Ljava/lang/String;)V", #Ars Nouveau (1.20.1-4.0.0)
+  "com.github.ars_zero.client.gui.AbstractMultiPhaseCastDeviceScreen:onSearchChanged(Ljava/lang/String;)V", #Ars Zero (1.21.1)
   "dev.emi.emi.search.NameQuery:matches(Ldev/emi/emi/api/stack/EmiStack;)Z", #EMI text search(Leagcy)
   "appeng.client.gui.me.interfaceterminal.InterfaceTerminalScreen:refreshList()V", #Applied Energistics
   "mcjty.rftools.items.netmonitor.GuiNetworkMonitor:populateList()V", #RF Tools


### PR DESCRIPTION
## Summary
- Adds pinyin search support for [Ars Zero](https://github.com/zeroregard/Ars-Zero), an Ars Nouveau add-on.
- Targets the abstract base class `AbstractMultiPhaseCastDeviceScreen.onSearchChanged(String)`, which uses `String.contains` style matching — hence the `contains` section.
- Concrete subclasses `ArsZeroStaffGUI` and `SpellcastingCircletGUI` inherit `onSearchChanged` unchanged, so a single entry covers both staff and circlet UIs.

## Test plan
- [ ] Build the mod and drop it into a 1.21.1 NeoForge instance with Ars Nouveau + Ars Zero installed.
- [ ] Open the Ars Zero staff GUI; type pinyin (e.g. `huoqiu`) in the search bar and verify Chinese glyph names (e.g. 火球) appear.
- [ ] Repeat with the Spellcasting Circlet GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)