### PR TITLE
Support Minecraft 26.2 (Fabric & NeoForge), fix #211

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ subprojects { Project subproject ->
         maven { url = "https://maven.blamejared.com/" }
         maven { url = "https://modmaven.dev" }
         maven { url = 'https://maven.parchmentmc.org' }
+        maven { url = 'https://maven.fabricmc.net/' }
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/common-unobfuscated/build.gradle
+++ b/common-unobfuscated/build.gradle
@@ -5,14 +5,14 @@ plugins {
 }
 
 neoForge {
-    neoFormVersion = '26.1.2-1'
+    neoFormVersion = '26.2-2'
 }
 
 
 dependencies {
     compileOnly(project(":common"))
     compileOnly "com.github.towdium:PinIn:${verpinin}"
-    compileOnly "mezz.jei:jei-26.1.2-common-api:${jei_unobfuscated_version}"
+    compileOnly "mezz.jei:jei-26.2-common-api:${jei_unobfuscated_version}"
     compileOnly 'com.google.auto.service:auto-service-annotations:1.1.1'
     annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
 }

--- a/common-unobfuscated/src/main/java/me/towdium/jecharacters/JechJeiPlugin.java
+++ b/common-unobfuscated/src/main/java/me/towdium/jecharacters/JechJeiPlugin.java
@@ -3,6 +3,7 @@ package me.towdium.jecharacters;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.registration.IAdvancedSearchRegistration;
+import mezz.jei.api.search.ISearchStorageFactory;
 import net.minecraft.resources.Identifier;
 
 @JeiPlugin
@@ -17,6 +18,6 @@ public class JechJeiPlugin implements IModPlugin {
     @Override
     public void registerAdvancedSearch(IAdvancedSearchRegistration registration) {
         JustEnoughCharacters.logger.info("Registering JEI pinyin search storage");
-        registration.replaceSearchStorage(JechSearchStorage::new);
+        registration.replaceSearchStorage((ISearchStorageFactory) JechSearchStorage::new);
     }
 }

--- a/common-unobfuscated/src/main/java/me/towdium/jecharacters/ModernMessageSender.java
+++ b/common-unobfuscated/src/main/java/me/towdium/jecharacters/ModernMessageSender.java
@@ -8,6 +8,6 @@ import net.minecraft.network.chat.Component;
 public class ModernMessageSender implements MessageSender {
     @Override
     public void sendMessage(String translationKey) {
-        Minecraft.getInstance().schedule(() -> Minecraft.getInstance().gui.getChat().addClientSystemMessage(Component.translatable(translationKey)));
+        Minecraft.getInstance().schedule(() -> Minecraft.getInstance().gui.hud.getChat().addClientSystemMessage(Component.translatable(translationKey)));
     }
 }

--- a/fabric-unobfuscated/build.gradle
+++ b/fabric-unobfuscated/build.gradle
@@ -21,9 +21,11 @@ dependencies {
     compileOnly project(':common')
     compileOnly(project(":fabric-common"))
     implementation project(":coremod-common")
-    compileOnly "mezz.jei:jei-${project.minecraft_version}-common-api:${jei_unobfuscated_version}"
-    compileOnly "mezz.jei:jei-${minecraft_version}-core:29.6.2.31"
-    compileOnly "mezz.jei:jei-${minecraft_version}-common:29.15.0.45"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_unobfuscated_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-core:30.1.0.12"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common:30.16.0.132"
+    // JEI 30.x removed mezz.jei.core.search.suffixtree; this pinned old core provides it for FakeTree compile only (compileOnly, not packaged)
+    compileOnly "mezz.jei:jei-26.1.2-core:29.6.2.31"
     compileOnly('net.mezzdev:suffixtree:1.1.0') {
         transitive = false
     }

--- a/fabric-unobfuscated/gradle.properties
+++ b/fabric-unobfuscated/gradle.properties
@@ -7,10 +7,10 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
-loader_version=0.19.2
+minecraft_version=26.2
+loader_version=0.19.3
 loom_version=1.16-SNAPSHOT
 
 # Dependencies
-fabric_api_version=0.146.1+26.1.2
+fabric_api_version=0.156.0+26.2
 suffixClassName=net/minecraft/client/searchtree/SuffixArray

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ fabric_version=0.138.3+1.21.10
 fabric_loader_version=0.19.2
 #mod deps
 jei_version=26.3.0.31
-jei_unobfuscated_version=29.16.0.46
+jei_unobfuscated_version=30.16.0.132

--- a/neoforge-unobfuscated/build.gradle
+++ b/neoforge-unobfuscated/build.gradle
@@ -12,7 +12,7 @@ base {
     archivesName = mod_id + '-' + minecraft_version + '-neoforge'
 }
 neoForge {
-    version = "26.1.2.59-beta"
+    version = "26.2.0.53-beta"
 
     def at = project(':common').file('src/main/resources/META-INF/accesstransformer.cfg')
     if (at.exists()) {
@@ -68,10 +68,12 @@ dependencies {
 
     jarJar(project(':coremod-neoforge'))
     jarJar(implementation("com.github.towdium:PinIn:${verpinin}"))
-    localRuntime "mezz.jei:jei-26.1.2-neoforge:${jei_unobfuscated_version}"
-    compileOnly "mezz.jei:jei-26.1.2-common-api:${jei_unobfuscated_version}"
-    compileOnly "mezz.jei:jei-${minecraft_version}-core:29.6.2.31"
-    compileOnly "mezz.jei:jei-${minecraft_version}-common:29.15.0.45"
+    localRuntime "mezz.jei:jei-${minecraft_version}-neoforge:${jei_unobfuscated_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_unobfuscated_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-core:30.1.0.12"
+    // JEI 30.x removed mezz.jei.core.search.suffixtree; this pinned old core provides it for FakeTree compile only (compileOnly, not packaged)
+    compileOnly "mezz.jei:jei-26.1.2-core:29.6.2.31"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common:30.16.0.132"
     compileOnly('net.mezzdev:suffixtree:1.1.0') {
         transitive = false
     }

--- a/neoforge-unobfuscated/gradle.properties
+++ b/neoforge-unobfuscated/gradle.properties
@@ -1,1 +1,1 @@
-minecraft_version=26.1.2
+minecraft_version=26.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 include('common', 'fabric-common', 'neoforge', 'coremod-common', 'coremod-neoforge', 'common-unobfuscated', 'fabric-unobfuscated', 'fabric-legacy', 'neoforge-unobfuscated')


### PR DESCRIPTION
## Summary
Update the 1.21.9+ branch to support Minecraft 26.2:
- Fabric build matrix -> 26.2 (loader 0.19.3, fabric-api 0.156.0+26.2, JEI 30.16.0.132)
- NeoForge unobfuscated build -> NeoForge 26.2.0.53-beta + JEI 30.x
- common-unobfuscated -> neoform 26.2-2

## Fixes
- Fix #211: 26.2 removed `Gui.getChat()`, ChatComponent moved to `Gui.hud.getChat()` (verified via javap on the official 26.2 deobf jar)
- JEI 30.x added `replaceSearchStorage(ISearchStorageBuilderFactory)` overload, making the method reference ambiguous -> explicit `ISearchStorageFactory` cast

## Build notes
- foojay-resolver-convention 0.8.0 -> 1.0.0 (0.8.0 crashes on Gradle 9: `JvmVendorSpec.IBM_SEMERU` was removed)
- Pinned `jei-26.1.2-core:29.6.2.31` on compileOnly: JEI 30.x removed `mezz.jei.core.search.suffixtree`, still needed to compile `FakeTree` (compileOnly only, not packaged)

## Testing
- Full `./gradlew build` passes (all modules)
- Fabric 26.2, verified in-game: JEI pinyin search works, `/jech profile` works (no crash)
- NeoForge 26.2: build verified only; not yet tested in-game

Closes #209 #211